### PR TITLE
Feat: Implement Epoch Tracking in Consensus Core

### DIFF
--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -91,11 +91,12 @@ class LogParser:
         if search(r'panic', log) is not None:
             raise ParseError('Node(s) panicked')
 
-        tmp = findall(r'\[(.*Z) .* Created B\d+ -> ([^ ]+=)', log)
+        # Since the new block structure prints out the round and the epoch, we slightly change the regex here for both Created and Committed logs
+        tmp = findall(r'\[(.*Z) .* Created B\d+(?:,\s*\d+)? -> ([^ ]+=)', log)
         tmp = [(d, self._to_posix(t)) for t, d in tmp]
         proposals = self._merge_results([tmp])
 
-        tmp = findall(r'\[(.*Z) .* Committed B\d+ -> ([^ ]+=)', log)
+        tmp = findall(r'\[(.*Z) .* Committed B\d+(?:,\s*\d+)? -> ([^ ]+=)', log)
         tmp = [(d, self._to_posix(t)) for t, d in tmp]
         commits = self._merge_results([tmp])
 

--- a/consensus/src/core.rs
+++ b/consensus/src/core.rs
@@ -1,5 +1,5 @@
 use crate::aggregator::Aggregator;
-use crate::config::Committee;
+use crate::config::{Committee, EpochNumber};
 use crate::consensus::{ConsensusMessage, Round};
 use crate::error::{ConsensusError, ConsensusResult};
 use crate::leader::LeaderElector;
@@ -23,6 +23,8 @@ use tokio::sync::mpsc::{Receiver, Sender};
 #[path = "tests/core_tests.rs"]
 pub mod core_tests;
 
+const ROUNDS_PER_EPOCH: Round = 5000; // 5k rounds/epoch gives us around 7 epochs per 20s bench run (assuming ~950 tx/s e2e, at 1k tx/s input)
+
 pub struct Core {
     name: PublicKey,
     committee: Committee,
@@ -38,6 +40,7 @@ pub struct Core {
     round: Round,
     last_voted_round: Round,
     last_committed_round: Round,
+    current_epoch: EpochNumber,
     high_qc: QC,
     timer: Timer,
     aggregator: Aggregator,
@@ -76,6 +79,7 @@ impl Core {
                 round: 1,
                 last_voted_round: 0,
                 last_committed_round: 0,
+                current_epoch: 1,
                 high_qc: QC::genesis(),
                 timer: Timer::new(timeout_delay),
                 aggregator: Aggregator::new(committee),
@@ -270,6 +274,33 @@ impl Core {
         if round < self.round {
             return;
         }
+
+        // Check if the round we are *completing* is the last of an epoch.
+        // Example: If ROUNDS_PER_EPOCH is 10:
+        // - Completing round 9 means next is round 10 (epoch 2). Change needed.
+        // - Completing round 19 means next is round 20 (epoch 3). Change needed.
+        // This assumes epochs E=1, 2, ... contain rounds (E-1)*N to E*N - 1.
+        // And round numbers start at 1 (genesis block is round 0, QC is round 0, first proposal is round 1).
+        // If round is the number of the block/QC triggering the advance:
+        // We advance *to* round + 1. Check if round + 1 starts a new epoch.
+        let next_round = round + 1;
+        if next_round > 0 && next_round % ROUNDS_PER_EPOCH == 0 { // Check if the *next* round is a multiple
+            // --- Epoch Change Triggered ---
+
+            // 1. Get the *new* epoch number
+            let new_epoch_number = (next_round / ROUNDS_PER_EPOCH) + 1; // Calculate the epoch we are entering
+
+            // 2. Update Core's current epoch tracker
+            self.current_epoch = new_epoch_number as EpochNumber;
+
+            // 3. Log the change
+            info!(
+                "EPOCH CHANGE: Preparing for round {}, entering Epoch {}",
+                next_round,
+                self.current_epoch
+            );
+        }
+
         // Reset the timer and advance round.
         self.timer.reset();
         self.round = round + 1;
@@ -282,7 +313,7 @@ impl Core {
     #[async_recursion]
     async fn generate_proposal(&mut self, tc: Option<TC>) {
         self.tx_proposer
-            .send(ProposerMessage::Make(self.round, self.high_qc.clone(), tc))
+            .send(ProposerMessage::Make(self.round, self.current_epoch, self.high_qc.clone(), tc))
             .await
             .expect("Failed to send message to proposer");
     }

--- a/consensus/src/messages.rs
+++ b/consensus/src/messages.rs
@@ -1,4 +1,4 @@
-use crate::config::Committee;
+use crate::config::{Committee, EpochNumber};
 use crate::consensus::Round;
 use crate::error::{ConsensusError, ConsensusResult};
 use crypto::{Digest, Hash, PublicKey, Signature, SignatureService};
@@ -19,6 +19,7 @@ pub struct Block {
     pub tc: Option<TC>,
     pub author: PublicKey,
     pub round: Round,
+    pub epoch: EpochNumber,
     pub payload: Vec<Digest>,
     pub signature: Signature,
 }
@@ -29,6 +30,7 @@ impl Block {
         tc: Option<TC>,
         author: PublicKey,
         round: Round,
+        epoch: EpochNumber,
         payload: Vec<Digest>,
         mut signature_service: SignatureService,
     ) -> Self {
@@ -37,6 +39,7 @@ impl Block {
             tc,
             author,
             round,
+            epoch,
             payload,
             signature: Signature::default(),
         };
@@ -81,6 +84,7 @@ impl Hash for Block {
         let mut hasher = Sha512::new();
         hasher.update(self.author.0);
         hasher.update(self.round.to_le_bytes());
+        hasher.update(self.epoch.to_le_bytes());
         for x in &self.payload {
             hasher.update(x);
         }
@@ -93,10 +97,11 @@ impl fmt::Debug for Block {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{}: B({}, {}, {:?}, {})",
+            "{}: B({}, {}, {}, {:?}, {})",
             self.digest(),
             self.author,
             self.round,
+            self.epoch,
             self.qc,
             self.payload.iter().map(|x| x.size()).sum::<usize>(),
         )
@@ -105,7 +110,7 @@ impl fmt::Debug for Block {
 
 impl fmt::Display for Block {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "B{}", self.round)
+        write!(f, "B{}, {}", self.round, self.epoch)
     }
 }
 

--- a/consensus/src/proposer.rs
+++ b/consensus/src/proposer.rs
@@ -1,4 +1,4 @@
-use crate::config::{Committee, Stake};
+use crate::config::{Committee, Stake, EpochNumber};
 use crate::consensus::{ConsensusMessage, Round};
 use crate::messages::{Block, QC, TC};
 use bytes::Bytes;
@@ -12,7 +12,7 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 #[derive(Debug)]
 pub enum ProposerMessage {
-    Make(Round, QC, Option<TC>),
+    Make(Round, EpochNumber, QC, Option<TC>),
     Cleanup(Vec<Digest>),
 }
 
@@ -58,13 +58,14 @@ impl Proposer {
         deliver
     }
 
-    async fn make_block(&mut self, round: Round, qc: QC, tc: Option<TC>) {
+    async fn make_block(&mut self, round: Round, epoch: EpochNumber, qc: QC, tc: Option<TC>) {
         // Generate a new block.
         let block = Block::new(
             qc,
             tc,
             self.name,
             round,
+            epoch,
             /* payload */ self.buffer.drain().collect(),
             self.signature_service.clone(),
         )
@@ -130,7 +131,9 @@ impl Proposer {
                     //}
                 },
                 Some(message) = self.rx_message.recv() => match message {
-                    ProposerMessage::Make(round, qc, tc) => self.make_block(round, qc, tc).await,
+                    ProposerMessage::Make(round, epoch, qc, tc) => {
+                        self.make_block(round, epoch, qc, tc).await
+                    },
                     ProposerMessage::Cleanup(digests) => {
                         for x in &digests {
                             self.buffer.remove(x);

--- a/consensus/src/tests/common.rs
+++ b/consensus/src/tests/common.rs
@@ -1,4 +1,4 @@
-use crate::config::Committee;
+use crate::config::{Committee, EpochNumber};
 use crate::consensus::Round;
 use crate::messages::{Block, Timeout, Vote, QC};
 use bytes::Bytes;
@@ -50,6 +50,7 @@ impl Block {
         qc: QC,
         author: PublicKey,
         round: Round,
+        epoch: EpochNumber,
         payload: Vec<Digest>,
         secret: &SecretKey,
     ) -> Self {
@@ -58,6 +59,7 @@ impl Block {
             tc: None,
             author,
             round,
+            epoch,
             payload,
             signature: Signature::default(),
         };
@@ -116,7 +118,7 @@ impl PartialEq for Timeout {
 // Fixture.
 pub fn block() -> Block {
     let (public_key, secret_key) = keys().pop().unwrap();
-    Block::new_from_key(QC::genesis(), public_key, 1, Vec::new(), &secret_key)
+    Block::new_from_key(QC::genesis(), public_key, 1, 1, Vec::new(), &secret_key)
 }
 
 // Fixture.
@@ -155,6 +157,7 @@ pub fn chain(keys: Vec<(PublicKey, SecretKey)>) -> Vec<Block> {
                 latest_qc.clone(),
                 *public_key,
                 1 + i as Round,
+                1,
                 Vec::new(),
                 secret_key,
             );

--- a/consensus/src/tests/core_tests.rs
+++ b/consensus/src/tests/core_tests.rs
@@ -100,7 +100,7 @@ async fn generate_proposal() {
     let (next_leader, next_leader_key) = leader_keys(2);
 
     // Make a block, votes, and QC.
-    let block = Block::new_from_key(QC::genesis(), leader, 1, Vec::new(), &leader_key);
+    let block = Block::new_from_key(QC::genesis(), leader, 1, 1, Vec::new(), &leader_key);
     let hash = block.digest();
     let votes: Vec<_> = keys()
         .iter()
@@ -131,8 +131,9 @@ async fn generate_proposal() {
 
     // Ensure the core sends a new block.
     match rx_proposer.recv().await.unwrap() {
-        ProposerMessage::Make(round, qc, tc) => {
+        ProposerMessage::Make(round, epoch, qc, tc) => {
             assert_eq!(round, 2);
+            assert_eq!(epoch, 1);
             assert_eq!(qc, hight_qc);
             assert!(tc.is_none());
         }


### PR DESCRIPTION
This PR introduces basic epoch tracking and transition logic to the HotStuff consensus core, addressing the first part for a potential "fast-sync" future implementation.
**Summary of Changes:**

* Added an `epoch: EpochNumber` (`u128`) field to the `Block` struct (`messages.rs`).
* Included the `epoch` field in the block's hash calculation.
* Added `current_epoch: EpochNumber` state variable to the `Core` struct (`core.rs`), initialized to 1.
* Defined a `ROUNDS_PER_EPOCH` constant (`core.rs`, set to 5000) to determine epoch length.
* Implemented logic in `Core::advance_round` to detect epoch boundaries based on the round number and increment `Core.current_epoch`.
* Added logging (`EPOCH CHANGE: ...`) to clearly indicate when epoch transitions occur.
* Updated relevant structures (`ProposerMessage`), functions (`Proposer::make_block`), and tests (`core_tests.rs`, `common.rs`) to accommodate the new epoch field.

**Testing:**

* Epoch change logic can be verified by running `fab local` and observing the `EPOCH CHANGE` logs in `benchmark/logs/`.