### PR TITLE
Feat: Add Fast Sync Preparation via Checkpoint Mechanism

### DIFF
--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -1,11 +1,17 @@
 from fabric import task
+import subprocess
+import os
+from time import sleep
+from math import ceil
 
 from benchmark.local import LocalBench
 from benchmark.logs import ParseError, LogParser
 from benchmark.utils import Print
 from benchmark.plot import Ploter, PlotError
 from benchmark.instance import InstanceManager
-from benchmark.remote import Bench, BenchError
+from benchmark.remote import Bench, BenchError, PathMaker
+from benchmark.commands import CommandMaker
+from benchmark.config import Key, LocalCommittee, NodeParameters, ConfigError
 
 
 @task
@@ -153,3 +159,154 @@ def logs(ctx):
         print(LogParser.process("./logs", faults="?").result())
     except ParseError as e:
         Print.error(BenchError("Failed to parse logs", e))
+
+# Params for the fast sync showcase
+DEFAULT_TEST_NODES = 4
+DEFAULT_TARGET_NODE_ID = 0 # Node to restart
+DEFAULT_PHASE1_DURATION = 30 # Seconds for initial run
+DEFAULT_PHASE2_DURATION = 10 # Seconds to observe restarted node
+
+# Node parameters (here are the same as local run)
+node_params_dict = {
+    "consensus": {
+        "timeout_delay": 1_000,
+        "sync_retry_delay": 10_000,
+    },
+    "mempool": {
+        "gc_depth": 50,
+        "sync_retry_delay": 5_000,
+        "sync_retry_nodes": 3,
+        "batch_size": 15_000,
+        "max_batch_delay": 100,
+    },
+}
+
+# Helper function to run command in tmux
+def run_in_tmux(command, log_file):
+    name = os.path.splitext(os.path.basename(log_file))[0]
+    cmd = f'{command} > {log_file} 2>&1'
+    subprocess.run(['tmux', 'new', '-d', '-s', name, cmd], check=False)
+
+# Helper function to kill tmux session
+def kill_tmux(session_name):
+     subprocess.run(['tmux', 'kill-session', '-t', session_name], stderr=subprocess.DEVNULL)
+
+@task
+def local_fast_sync(ctx, nodes=DEFAULT_TEST_NODES, target_node=DEFAULT_TARGET_NODE_ID, duration1=DEFAULT_PHASE1_DURATION):
+    """
+    Runs a local test scenario for fast-sync startup, including cleanup.
+    """
+    Print.heading("Starting Local Fast-Sync Test Scenario")
+    # Keep track of started session names for cleanup
+    initial_node_sessions = [f'node-{i}' for i in range(nodes)]
+    restarted_node_session = f'node-{target_node}_restarted' # Name based on log file used
+
+    try:
+        # --- 0. Initial Cleanup ---
+        Print.info("Initial cleanup...")
+        # Kill previous sessions using expected names
+        for i in range(nodes):
+             kill_tmux(f'node-{i}')
+             kill_tmux(f'node-{i}_restarted') # Kill restarted session too if exists
+        # Cleanup
+        cmd_clean = f'{CommandMaker.clean_logs()} ; {CommandMaker.cleanup()}'
+        subprocess.run([cmd_clean], shell=True, stderr=subprocess.DEVNULL)
+        sleep(0.5)
+
+        # --- 1. Build Default Binary ---
+        Print.info("Building default node binary...")
+        cmd_build_default = CommandMaker.compile().split()
+        subprocess.run(cmd_build_default, cwd=PathMaker.node_crate_path(), check=True)
+        # Alias the just-built binary
+        subprocess.run([CommandMaker.alias_binaries(PathMaker.binary_path())], shell=True)
+
+        # --- 2. Generate Configs ---
+        Print.info("Generating configuration files...")
+        keys = []
+        key_files = [PathMaker.key_file(i) for i in range(nodes)]
+        for i, filename in enumerate(key_files):
+            cmd = CommandMaker.generate_key(filename).split()
+            subprocess.run(cmd, check=True)
+            keys.append(Key.from_file(filename))
+
+        names = [x.name for x in keys]
+        committee = LocalCommittee(names, 9500)
+        committee.print(PathMaker.committee_file())
+
+        node_parameters = NodeParameters(node_params_dict)
+        node_parameters.print(PathMaker.parameters_file())
+
+        # --- 3. Run Initial Cluster (Phase 1) ---
+        Print.info(f"Starting initial cluster ({nodes} nodes) for {duration1} seconds...")
+        # Start nodes using the default binary
+        for i in range(nodes):
+            cmd = CommandMaker.run_node(
+                PathMaker.key_file(i),
+                PathMaker.committee_file(),
+                PathMaker.db_path(i),
+                PathMaker.parameters_file(),
+                debug=True
+            )
+            log_file = PathMaker.node_log_file(i)
+            run_in_tmux(cmd, log_file)
+            Print.info(f"Node {i} started. Log: {log_file}")
+
+        Print.info(f"Waiting {duration1} seconds for cluster to run past epoch 1...")
+        sleep(duration1)
+
+        # --- 4. Stop Target Node ---
+        Print.info(f"Stopping target node {target_node}...")
+        kill_tmux(f'node-{target_node}')
+        sleep(1) # Give it a moment to die
+
+        # --- 5. Clear Target Store ---
+        Print.info(f"Clearing store for target node {target_node}...")
+        db_path = PathMaker.db_path(target_node)
+        subprocess.run(f'rm -rf {db_path}', shell=True, check=False)
+
+        # --- 6. Build Fast-Sync Binary ---
+        Print.info("Building node binary with 'fast-sync' feature...")
+        # Explicitly add features.
+        cmd_build_fast_sync = [
+            'cargo', 'build', '--release',
+            '--features', 'fast-sync' # Add fast-sync feature
+        ]
+        subprocess.run(cmd_build_fast_sync, cwd=PathMaker.node_crate_path(), check=True)
+        # Re-alias binaries to use the new build
+        subprocess.run([CommandMaker.alias_binaries(PathMaker.binary_path())], shell=True)
+
+        # --- 7. Restart Target Node ---
+        Print.info(f"Restarting target node {target_node} using fast-sync binary...")
+        cmd_restart = CommandMaker.run_node(
+            PathMaker.key_file(target_node),
+            PathMaker.committee_file(),
+            PathMaker.db_path(target_node),
+            PathMaker.parameters_file(),
+            debug=True
+        )
+        log_file_restarted = f"{PathMaker.logs_path()}/node-{target_node}_restarted.log"
+        run_in_tmux(cmd_restart, log_file_restarted)
+
+        # --- 8. Inform User ---
+        Print.heading("Fast Sync Local Test Scenario Initialized!")
+
+        # --- 9. Wait and Cleanup ---
+        Print.info(f"Waiting {DEFAULT_PHASE2_DURATION}s before cleaning up...")
+        sleep(DEFAULT_PHASE2_DURATION)
+
+    except (subprocess.SubprocessError, ConfigError, BenchError) as e:
+        Print.error(BenchError(f"Local fast-sync test failed: {e}", e))
+        # Ensure cleanup happens even on error
+    except Exception as e:
+         Print.error(BenchError(f"An unexpected error occurred: {e}", e))
+        # Ensure cleanup happens even on error
+    finally:
+        # --- FINAL CLEANUP ---
+        Print.info("Cleaning up test nodes...")
+        for i in range(nodes):
+            # Kill initial nodes that weren't the target (target was already killed)
+            if i != target_node:
+                kill_tmux(f'node-{i}')
+        # Kill the restarted node session
+        kill_tmux(restarted_node_session)
+        Print.info("Cleanup complete.")

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -29,3 +29,4 @@ rand = "0.7.3"
 
 [features]
 benchmark = []
+fast-sync = []

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -1,7 +1,7 @@
 use crate::config::{Committee, Parameters};
 use crate::core::Core;
 use crate::error::ConsensusError;
-use crate::helper::Helper;
+use crate::helper::{Helper, HelperRequest};
 use crate::leader::LeaderElector;
 use crate::mempool::MempoolDriver;
 use crate::messages::{Block, Timeout, Vote, TC};
@@ -36,6 +36,14 @@ pub enum ConsensusMessage {
     Timeout(Timeout),
     TC(TC),
     SyncRequest(Digest, PublicKey),
+    SyncCheckpointRequest(PublicKey), // Request latest checkpoint info from sender
+    SyncCheckpointResponse(Option<Block>), // Respond with the first block of the latest finalized epoch known
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum CoreStartMode {
+    Genesis,
+    FastSync,
 }
 
 pub struct Consensus;
@@ -51,6 +59,7 @@ impl Consensus {
         rx_mempool: Receiver<Digest>,
         tx_mempool: Sender<ConsensusMempoolMessage>,
         tx_commit: Sender<Block>,
+        start_mode: CoreStartMode,
     ) {
         // NOTE: This log entry is used to compute performance.
         parameters.log();
@@ -58,7 +67,7 @@ impl Consensus {
         let (tx_consensus, rx_consensus) = channel(CHANNEL_CAPACITY);
         let (tx_loopback, rx_loopback) = channel(CHANNEL_CAPACITY);
         let (tx_proposer, rx_proposer) = channel(CHANNEL_CAPACITY);
-        let (tx_helper, rx_helper) = channel(CHANNEL_CAPACITY);
+        let (tx_helper, rx_helper): (Sender<HelperRequest>, Receiver<HelperRequest>) = channel(CHANNEL_CAPACITY);
 
         // Spawn the network receiver.
         let mut address = committee
@@ -70,7 +79,7 @@ impl Consensus {
             /* handler */
             ConsensusReceiverHandler {
                 tx_consensus,
-                tx_helper,
+                tx_helper: tx_helper.clone(),
             },
         );
         info!(
@@ -107,6 +116,8 @@ impl Consensus {
             rx_loopback,
             tx_proposer,
             tx_commit,
+            start_mode,
+            tx_helper,
         );
 
         // Spawn the block proposer.
@@ -128,34 +139,75 @@ impl Consensus {
 #[derive(Clone)]
 struct ConsensusReceiverHandler {
     tx_consensus: Sender<ConsensusMessage>,
-    tx_helper: Sender<(Digest, PublicKey)>,
+    tx_helper: Sender<HelperRequest>,
 }
 
 #[async_trait]
 impl MessageHandler for ConsensusReceiverHandler {
     async fn dispatch(&self, writer: &mut Writer, serialized: Bytes) -> Result<(), Box<dyn Error>> {
-        // Deserialize and parse the message.
-        match bincode::deserialize(&serialized).map_err(ConsensusError::SerializationError)? {
-            ConsensusMessage::SyncRequest(missing, origin) => self
-                .tx_helper
-                .send((missing, origin))
-                .await
-                .expect("Failed to send consensus message"),
+        // Deserialize the message
+        let message = bincode::deserialize(&serialized);
+
+        // Handle potential deserialization errors
+        let consensus_message: ConsensusMessage = match message {
+            Ok(msg) => msg,
+            Err(e) => {
+                // Log the error and return without crashing
+                log::warn!("Failed to deserialize consensus message: {}", e);
+                // Return the serialization error, wrapped
+                return Err(Box::new(ConsensusError::SerializationError(e)));
+            }
+        };
+
+        match consensus_message {
+            // --- Handle Requests intended for Helper ---
+            ConsensusMessage::SyncRequest(missing, origin) => {
+                // Route to Helper task with the specific request type
+                self.tx_helper
+                    .send(HelperRequest::GetBlock(missing, origin))
+                    .await
+                    // Consider returning Err instead of panic for robustness
+                    .map_err(|e| Box::new(e) as Box<dyn Error>)?;
+            }
+            ConsensusMessage::SyncCheckpointRequest(origin) => {
+                // Route to Helper task with the specific request type
+                self.tx_helper
+                    .send(HelperRequest::GetCheckpoint(origin))
+                    .await
+                    // Consider returning Err instead of panic
+                    .map_err(|e| Box::new(e) as Box<dyn Error>)?;
+            }
+
+            // --- Handle Responses or Messages for Core ---
             message @ ConsensusMessage::Propose(..) => {
-                // Reply with an ACK.
+                // ReliableSender expects an ACK for proposals
                 let _ = writer.send(Bytes::from("Ack")).await;
 
                 // Pass the message to the consensus core.
                 self.tx_consensus
                     .send(message)
                     .await
-                    .expect("Failed to consensus message")
+                    .map_err(|e| Box::new(e) as Box<dyn Error>)?;
             }
-            message => self
-                .tx_consensus
-                .send(message)
-                .await
-                .expect("Failed to consensus message"),
+            message @ ConsensusMessage::SyncCheckpointResponse(..) => {
+                // This is a response to *our* request during fast-sync startup.
+                // Route it to the Core, which needs logic (under cfg flag) to handle it.
+                // SimpleSender used for the response doesn't need an ACK from us here.
+                self.tx_consensus
+                    .send(message)
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn Error>)?;
+            }
+
+            // --- Default Handler for other Core messages (Vote, Timeout, TC) ---
+            message => {
+                // These messages (Vote, Timeout, TC) typically don't require ACKs in this design
+                 // Pass the message to the consensus core.
+                self.tx_consensus
+                    .send(message)
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn Error>)?;
+            }
         }
         Ok(())
     }

--- a/consensus/src/core.rs
+++ b/consensus/src/core.rs
@@ -1,6 +1,6 @@
 use crate::aggregator::Aggregator;
 use crate::config::{Committee, EpochNumber};
-use crate::consensus::{ConsensusMessage, Round};
+use crate::consensus::{ConsensusMessage, Round, CoreStartMode};
 use crate::error::{ConsensusError, ConsensusResult};
 use crate::leader::LeaderElector;
 use crate::mempool::MempoolDriver;
@@ -8,6 +8,7 @@ use crate::messages::{Block, Timeout, Vote, QC, TC};
 use crate::proposer::ProposerMessage;
 use crate::synchronizer::Synchronizer;
 use crate::timer::Timer;
+use crate::helper::HelperRequest;
 use async_recursion::async_recursion;
 use bytes::Bytes;
 use crypto::Hash as _;
@@ -18,6 +19,9 @@ use std::cmp::max;
 use std::collections::VecDeque;
 use store::Store;
 use tokio::sync::mpsc::{Receiver, Sender};
+
+#[cfg(feature = "fast-sync")]
+use tokio::time::{sleep, Duration};
 
 #[cfg(test)]
 #[path = "tests/core_tests.rs"]
@@ -45,6 +49,7 @@ pub struct Core {
     timer: Timer,
     aggregator: Aggregator,
     network: SimpleSender,
+    tx_helper: Sender<HelperRequest>,
 }
 
 impl Core {
@@ -62,6 +67,8 @@ impl Core {
         rx_loopback: Receiver<Block>,
         tx_proposer: Sender<ProposerMessage>,
         tx_commit: Sender<Block>,
+        start_mode: CoreStartMode,
+        tx_helper: Sender<HelperRequest>,
     ) {
         tokio::spawn(async move {
             Self {
@@ -76,6 +83,7 @@ impl Core {
                 rx_loopback,
                 tx_proposer,
                 tx_commit,
+                tx_helper,
                 round: 1,
                 last_voted_round: 0,
                 last_committed_round: 0,
@@ -85,7 +93,7 @@ impl Core {
                 aggregator: Aggregator::new(committee),
                 network: SimpleSender::new(),
             }
-            .run()
+            .run(start_mode)
             .await
         });
     }
@@ -333,6 +341,27 @@ impl Core {
     }
 
     async fn process_qc(&mut self, qc: &QC) {
+        // Check if processing this QC completes an epoch
+        let next_round = qc.round + 1; // The round number we would enter *after* this block
+
+        // Ensure we don't checkpoint for Genesis (qc.round 0)
+        // Check if qc.round is the last round of an epoch
+        if qc.round > 0 && next_round % ROUNDS_PER_EPOCH == 0 {
+            let digest = qc.hash.clone(); // The digest of the block certified by this QC (last block of epoch)
+
+            // This block is the last one of the epoch ending at qc.round.
+            // Send an update to the Helper task to mark this block's digest as the new checkpoint.
+            info!(
+                "Core: Epoch {} ending. Marking block {} (Round {}) as the new checkpoint.",
+                self.current_epoch, // Log epoch number *before* advance_round might update it
+                digest,
+                qc.round
+            );
+            if let Err(e) = self.tx_helper.send(HelperRequest::UpdateCheckpoint(digest)).await {
+                // Log error but don't necessarily stop consensus progress
+                error!("Core: Failed to send checkpoint update to Helper: {}", e);
+            }
+        }
         self.advance_round(qc.round).await;
         self.update_high_qc(qc);
     }
@@ -440,24 +469,143 @@ impl Core {
         Ok(())
     }
 
-    pub async fn run(&mut self) {
-        // Upon booting, generate the very first block (if we are the leader).
-        // Also, schedule a timer in case we don't hear from the leader.
+    #[cfg_attr(not(feature = "fast-sync"), allow(unused_variables))]
+    pub async fn run(&mut self, start_mode: CoreStartMode) {
+        // Log the received mode IMMEDIATELY for debugging
+        info!("Core::run entered with start_mode: {:?}", start_mode);
+        // --- Fast Sync Initialization Phase ---
+        // This block only runs if the 'fast-sync' feature is enabled AND
+        // the start_mode requests it.
+        #[cfg(feature = "fast-sync")]
+        if matches!(start_mode, CoreStartMode::FastSync) {
+            info!("Fast Sync: Core entering sync mode...");
+            const FAST_SYNC_TIMEOUT_MS: u64 = 10_000; // 10 second timeout
+
+            // 1. Request Checkpoint from a peer
+            // Simplification: Ask the first peer we know (excluding ourselves)
+            let peers = self.committee.broadcast_addresses(&self.name);
+            let mut checkpoint_fetched = false;
+            if let Some((_peer_name, peer_addr)) = peers.first() {
+                info!("Fast Sync: Requesting checkpoint from {}", peer_addr);
+                let request = ConsensusMessage::SyncCheckpointRequest(self.name);
+                match bincode::serialize(&request) {
+                    Ok(serialized_request) => {
+                        self.network.send(*peer_addr, Bytes::from(serialized_request)).await;
+                    }
+                    Err(e) => {
+                        error!("Fast Sync: Failed to serialize checkpoint request: {}", e);
+                        // Proceed to normal startup without checkpoint
+                    }
+                }
+
+                // 2. Wait for Response or Timeout
+                let deadline = sleep(Duration::from_millis(FAST_SYNC_TIMEOUT_MS));
+                tokio::pin!(deadline);
+
+                loop {
+                    tokio::select! {
+                        biased;
+                        // Check for incoming messages
+                        maybe_message = self.rx_message.recv() => {
+                            match maybe_message {
+                                Some(ConsensusMessage::SyncCheckpointResponse(Some(checkpoint_block))) => {
+                                    info!("Fast Sync: Received checkpoint block {}", checkpoint_block);
+
+                                    // --- PoC Verification ---
+                                    // WARNING: Very happy-path approach.
+                                    match checkpoint_block.verify(&self.committee) {
+                                        Ok(()) => {
+                                            info!("Fast Sync: Checkpoint verified (basic). Initializing state.");
+                                            // TODO: Ideally, fetch parent block too to ensure commit rules work
+                                            // For PoC, we might skip this, but log a warning. We also might have
+                                            // some specific finality logic but deffo out of scope.
+                                            warn!("Fast Sync PoC: Parent block of checkpoint not fetched/verified.");
+
+                                            // Initialize Core state based on the checkpoint
+                                            self.current_epoch = checkpoint_block.epoch;
+                                            self.round = checkpoint_block.round + 1; // Start round *after* checkpoint
+                                            self.high_qc = checkpoint_block.qc.clone();
+                                            self.last_voted_round = checkpoint_block.round;
+                                            // Simplification: Set commit round based on QC. Not fully correct finality.
+                                            self.last_committed_round = self.high_qc.round;
+
+                                            // Store the checkpoint block
+                                            self.store_block(&checkpoint_block).await;
+                                            checkpoint_fetched = true; // Mark success
+                                            break; // Exit the response waiting loop
+                                        }
+                                        Err(e) => {
+                                            warn!("Fast Sync: Received invalid checkpoint block: {}", e);
+                                            // Continue waiting for potentially other responses or timeout
+                                        }
+                                    }
+                                }
+                                Some(ConsensusMessage::SyncCheckpointResponse(None)) => {
+                                    info!("Fast Sync: Peer responded with no checkpoint block.");
+                                    // Continue waiting
+                                }
+                                Some(other_message) => {
+                                    // It's possible other messages arrive while waiting. Just log.
+                                    warn!("Fast Sync: Ignoring non-checkpoint message {:?} during sync phase", other_message);
+                                }
+                                None => { // Channel closed
+                                     warn!("Fast Sync: Message channel closed unexpectedly. Starting from Genesis.");
+                                     break; // Exit the response waiting loop
+                                }
+                            }
+                        },
+
+                        // Handle timeout
+                        () = &mut deadline => {
+                            warn!("Fast Sync: Timeout waiting for checkpoint response. Starting from Genesis.");
+                            break; // Exit the response waiting loop
+                        },
+                    }
+                } // End of response waiting loop
+
+            } else {
+                warn!("Fast Sync: No peers found to request checkpoint from. Starting from Genesis.");
+            }
+
+            // If sync failed, core state remains at Genesis defaults. If succeeded, it's updated.
+             if checkpoint_fetched {
+                 info!("Fast Sync: Successfully initialized state from checkpoint.");
+             } else {
+                 info!("Fast Sync: Failed to obtain valid checkpoint, proceeding with Genesis state.");
+             }
+
+        } // End of #[cfg(feature = "fast-sync")] block
+
+
+        // --- Normal Startup / Post-Sync ---
+        // Initialize timer and potentially generate first block based on the current state
+        // (which might be Genesis or from fast sync)
         self.timer.reset();
+        info!("Core starting normal operation at Epoch {}, Round {}", self.current_epoch, self.round);
         if self.name == self.leader_elector.get_leader(self.round) {
+            // generate_proposal uses self.round, self.current_epoch, self.high_qc which are now set correctly.
             self.generate_proposal(None).await;
         }
 
-        // This is the main loop: it processes incoming blocks and votes,
-        // and receive timeout notifications from our Timeout Manager.
+        // --- Main Loop ---
         loop {
             let result = tokio::select! {
-                Some(message) = self.rx_message.recv() => match message {
-                    ConsensusMessage::Propose(block) => self.handle_proposal(&block).await,
-                    ConsensusMessage::Vote(vote) => self.handle_vote(&vote).await,
-                    ConsensusMessage::Timeout(timeout) => self.handle_timeout(&timeout).await,
-                    ConsensusMessage::TC(tc) => self.handle_tc(tc).await,
-                    _ => panic!("Unexpected protocol message")
+                Some(message) = self.rx_message.recv() => {
+                    // Add guards to ignore sync messages during normal operation
+                    match message {
+                        ConsensusMessage::SyncCheckpointRequest(_) | ConsensusMessage::SyncCheckpointResponse(_) => {
+                            warn!("Ignoring sync checkpoint message during normal operation.");
+                            Ok(()) // Return Ok to avoid outer error handling
+                        }
+                        ConsensusMessage::Propose(block) => self.handle_proposal(&block).await,
+                        ConsensusMessage::Vote(vote) => self.handle_vote(&vote).await,
+                        ConsensusMessage::Timeout(timeout) => self.handle_timeout(&timeout).await,
+                        ConsensusMessage::TC(tc) => self.handle_tc(tc).await,
+                        ConsensusMessage::SyncRequest(_,_) => {
+                           warn!("Ignoring SyncRequest received in Core loop.");
+                           Ok(())
+                        }
+                    }
                 },
                 Some(block) = self.rx_loopback.recv() => self.process_block(&block).await,
                 () = &mut self.timer => self.local_timeout_round().await,
@@ -468,6 +616,6 @@ impl Core {
                 Err(ConsensusError::SerializationError(e)) => error!("Store corrupted. {}", e),
                 Err(e) => warn!("{}", e),
             }
-        }
-    }
+        } // End of main loop
+    } // End of run function
 }

--- a/consensus/src/helper.rs
+++ b/consensus/src/helper.rs
@@ -1,3 +1,5 @@
+use log::{info, debug, error};
+use crate::Block;
 use crate::config::Committee;
 use crate::consensus::ConsensusMessage;
 use bytes::Bytes;
@@ -11,57 +13,141 @@ use tokio::sync::mpsc::Receiver;
 #[path = "tests/helper_tests.rs"]
 pub mod helper_tests;
 
+#[derive(Debug)]
+pub enum HelperRequest {
+    GetBlock(Digest, PublicKey), // Request for a specific block by digest
+    GetCheckpoint(PublicKey),    // Request for the latest checkpoint block
+    UpdateCheckpoint(Digest),    // Request to update the checkpoint block
+}
+
 /// A task dedicated to help other authorities by replying to their sync requests.
 pub struct Helper {
     /// The committee information.
     committee: Committee,
     /// The persistent storage.
     store: Store,
-    /// Input channel to receive sync requests.
-    rx_requests: Receiver<(Digest, PublicKey)>,
+    /// Input channel to receive sync requests. Changed type to HelperRequest.
+    rx_requests: Receiver<HelperRequest>,
     /// A network sender to reply to the sync requests.
     network: SimpleSender,
+    /// Current checkpoint block digest
+    current_checkpoint_digest: Option<Digest>,
 }
 
 impl Helper {
-    pub fn spawn(committee: Committee, store: Store, rx_requests: Receiver<(Digest, PublicKey)>) {
+    // Spawn function already correctly updated to accept Receiver<HelperRequest>
+    pub fn spawn(committee: Committee, store: Store, rx_requests: Receiver<HelperRequest>) {
         tokio::spawn(async move {
             Self {
                 committee,
                 store,
                 rx_requests,
                 network: SimpleSender::new(),
+                current_checkpoint_digest: None,
             }
             .run()
             .await;
         });
     }
 
+    // Updated run loop to handle HelperRequest enum
     async fn run(&mut self) {
-        while let Some((digest, origin)) = self.rx_requests.recv().await {
-            // TODO [issue #58]: Do some accounting to prevent bad nodes from monopolizing our resources.
+        while let Some(request) = self.rx_requests.recv().await { // <-- Receive the enum
+            match request {
+                HelperRequest::GetBlock(digest, origin) => { // <-- Handle GetBlock variant
+                    // Get the requester's address.
+                    let address = match self.committee.address(&origin) {
+                        Some(x) => x,
+                        None => {
+                            warn!("Received GetBlock request from unknown authority: {}", origin);
+                            continue; // Skip if origin is unknown
+                        }
+                    };
 
-            // get the requestors address.
-            let address = match self.committee.address(&origin) {
-                Some(x) => x,
-                None => {
-                    warn!("Received sync request from unknown authority: {}", origin);
-                    continue;
+                    // Reply with the requested block data (if we have it).
+                    match self.store.read(digest.to_vec()).await {
+                        Ok(Some(bytes)) => {
+                            // Attempt to deserialize to ensure it's a valid block before sending
+                            match bincode::deserialize::<Block>(&bytes) {
+                                Ok(block) => {
+                                    let message = bincode::serialize(&ConsensusMessage::Propose(block))
+                                        .expect("Failed to serialize block"); // Should generally not fail
+                                    self.network.send(address, Bytes::from(message)).await;
+                                    debug!("Served block {} to {}", digest, origin);
+                                }
+                                Err(e) => {
+                                    error!("Failed to deserialize block {} from store: {}", digest, e);
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            // Block not found, do nothing. The requester will likely retry.
+                            debug!("Block {} not found for GetBlock request from {}", digest, origin);
+                        }
+                        Err(e) => {
+                            error!("Failed to read store for GetBlock request {}: {}", digest, e);
+                        }
+                    }
                 }
-            };
 
-            // Reply to the request (if we can).
-            if let Some(bytes) = self
-                .store
-                .read(digest.to_vec())
-                .await
-                .expect("Failed to read from storage")
-            {
-                let block =
-                    bincode::deserialize(&bytes).expect("Failed to deserialize our own block");
-                let message = bincode::serialize(&ConsensusMessage::Propose(block))
-                    .expect("Failed to serialize block");
-                self.network.send(address, Bytes::from(message)).await;
+                HelperRequest::UpdateCheckpoint(new_digest) => { // <-- Handle UpdateCheckpoint message from Core
+                    info!("Helper: Received checkpoint update: {}", new_digest);
+                    self.current_checkpoint_digest = Some(new_digest);
+                }
+
+                HelperRequest::GetCheckpoint(origin) => { // <-- Handle GetCheckpoint variant
+                    // Get the requester's address.
+                     let address = match self.committee.address(&origin) {
+                        Some(x) => x,
+                        None => {
+                            warn!("Received GetCheckpoint request from unknown authority: {}", origin);
+                            continue; // Skip if origin is unknown
+                        }
+                    };
+
+                    // Start the checkpoint block logic
+                    let mut checkpoint_block: Option<Block> = None;
+                    // Check if core has given us a checkpoint block
+                    if let Some(digest_to_serve) = self.current_checkpoint_digest.clone() {
+                        info!("Helper: Serving checkpoint {} for request from {}", digest_to_serve, origin);
+                        match self.store.read(digest_to_serve.to_vec()).await {
+                            Ok(Some(block_bytes)) => {
+                                match bincode::deserialize::<Block>(&block_bytes) {
+                                    Ok(block) => {
+                                        checkpoint_block = Some(block);
+                                    }
+                                    Err(e) => {
+                                        error!("Helper: Failed to deserialize stored checkpoint block {}: {}", digest_to_serve, e);
+                                        // Keep checkpoint_block = None
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                warn!("Helper: Stored checkpoint digest {} points to block not found in store!", digest_to_serve);
+                                // Keep checkpoint_block = None
+                            }
+                             Err(e) => {
+                                error!("Helper: Failed to read stored checkpoint block {} from store: {}", digest_to_serve, e);
+                                // Keep checkpoint_block = None
+                            }
+                        }
+                    } else {
+                        warn!("Helper: No checkpoint digest set by Core yet. Cannot serve checkpoint for {}", origin);
+                        // Keep checkpoint_block = None
+                    }
+
+                    // Serialize and send the response (which might contain None).
+                    let response = ConsensusMessage::SyncCheckpointResponse(checkpoint_block.clone());
+                    match bincode::serialize(&response) {
+                        Ok(serialized) => {
+                            debug!("Sending SyncCheckpointResponse (contains_block: {}) to {}", checkpoint_block.is_some(), origin);
+                            self.network.send(address, Bytes::from(serialized)).await;
+                        }
+                        Err(e) => {
+                             error!("Failed to serialize SyncCheckpointResponse: {}", e);
+                        }
+                    }
+                }
             }
         }
     }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -17,5 +17,5 @@ mod timer;
 mod common;
 
 pub use crate::config::{Committee, Parameters};
-pub use crate::consensus::Consensus;
+pub use crate::consensus::{Consensus, CoreStartMode};
 pub use crate::messages::{Block, QC, TC};

--- a/consensus/src/tests/consensus_tests.rs
+++ b/consensus/src/tests/consensus_tests.rs
@@ -6,6 +6,7 @@ use futures::future::try_join_all;
 use std::fs;
 use tokio::sync::mpsc::channel;
 use tokio::task::JoinHandle;
+use crate::consensus::CoreStartMode;
 
 fn spawn_nodes(
     keys: Vec<(PublicKey, SecretKey)>,
@@ -46,6 +47,7 @@ fn spawn_nodes(
                     rx_mempool_to_consensus,
                     tx_consensus_to_mempool,
                     tx_commit,
+                    CoreStartMode::Genesis,
                 );
 
                 rx_commit.recv().await.unwrap()

--- a/consensus/src/tests/core_tests.rs
+++ b/consensus/src/tests/core_tests.rs
@@ -20,6 +20,7 @@ fn core(
     let (tx_proposer, rx_proposer) = channel(1);
     let (tx_mempool, mut rx_mempool) = channel(1);
     let (tx_commit, rx_commit) = channel(1);
+    let (tx_helper, _rx_helper): (Sender<HelperRequest>, Receiver<HelperRequest>) = channel(1);
 
     let signature_service = SignatureService::new(secret);
     let _ = fs::remove_dir_all(store_path);
@@ -53,6 +54,8 @@ fn core(
         rx_loopback,
         tx_proposer,
         tx_commit,
+        CoreStartMode::Genesis,
+        tx_helper,
     );
 
     (tx_core, rx_proposer, rx_commit)

--- a/consensus/src/tests/helper_tests.rs
+++ b/consensus/src/tests/helper_tests.rs
@@ -30,7 +30,7 @@ async fn sync_reply() {
     let handle = listener(address, Some(expected));
 
     // Send a sync request.
-    tx_request.send((digest, requestor)).await.unwrap();
+    tx_request.send(HelperRequest::GetBlock(digest, requestor)).await.unwrap();
 
     // Ensure the requestor received the batch (ie. it did not panic).
     assert!(handle.await.is_ok());

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,6 +27,7 @@ mempool = { path = "../mempool" }
 
 [features]
 benchmark = ["consensus/benchmark", "mempool/benchmark"]
+fast-sync = ["consensus/fast-sync"]
 
 [[bin]]         
 name = "client"   

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -1,6 +1,6 @@
 use crate::config::Export as _;
 use crate::config::{Committee, ConfigError, Parameters, Secret};
-use consensus::{Block, Consensus};
+use consensus::{Block, Consensus, CoreStartMode};
 use crypto::SignatureService;
 use log::info;
 use mempool::Mempool;
@@ -53,6 +53,18 @@ impl Node {
             tx_mempool_to_consensus,
         );
 
+        // Determine the start mode based on the feature flag
+        #[cfg(feature = "fast-sync")]
+        let start_mode = {
+            info!("'fast-sync' feature enabled, instructing Core to attempt fast sync.");
+            CoreStartMode::FastSync
+        };
+        #[cfg(not(feature = "fast-sync"))]
+        let start_mode = {
+            info!("Starting node normally from Genesis.");
+            CoreStartMode::Genesis
+        };
+
         // Run the consensus core.
         Consensus::spawn(
             name,
@@ -63,6 +75,7 @@ impl Node {
             rx_mempool_to_consensus,
             tx_consensus_to_mempool,
             tx_commit,
+            start_mode,
         );
 
         info!("Node {} successfully booted", name);


### PR DESCRIPTION
**Depends on: PR #1** (Merges into the branch from PR #1)

This PR implements the preparation for fast synchronization based on epoch boundaries. It builds directly upon the epoch implementation introduced in PR #1.

The chosen approach uses a checkpoint request/response system managed by the `Helper` task.

**Summary of Changes:**

* Introduced `ConsensusMessage` variants: `SyncCheckpointRequest(PublicKey)` and `SyncCheckpointResponse(Option<Block>)`.
* Introduced an internal `HelperRequest` enum (`helper.rs`) with variants like `UpdateCheckpoint(Digest)` and `GetCheckpoint(PublicKey)`.
* Modified the `Helper` struct (`helper.rs`) to:
    * Store the latest `current_checkpoint_digest: Option<Digest>`.
    * Handle `UpdateCheckpoint` requests from `Core` to store the digest.
    * Handle `GetCheckpoint` requests (forwarded from the network handler) to read the corresponding block from the `Store` and send a `SyncCheckpointResponse`.
* Modified `Core::process_qc` (`core.rs`) to identify the end of an epoch and send `HelperRequest::UpdateCheckpoint(qc.hash)` to the `Helper` via a new `tx_helper` channel.
* Updated `ConsensusReceiverHandler` (`consensus.rs`) to route incoming `SyncCheckpointRequest` messages to the `Helper` task via the `tx_helper` channel.
* Updated `Consensus::spawn` (`consensus.rs`) to create and wire the `tx_helper`/`rx_helper` channel between `Core` and `Helper`.
* Includes client-side logic in `Core::run` (gated by `fast-sync` feature flag) to request and initialize from a checkpoint, used by the `fab local-fast-sync` test.

**Testing:**

* The full checkpoint serving and (test-mode) client initialization flow can be verified by running `fab local-fast-sync` and inspecting the logs in `benchmark/logs/` (specifically `node-0_restarted.log` and logs from nodes 1-3).